### PR TITLE
Feat: OpenBySerial + free DeviceList

### DIFF
--- a/hackrf/device.go
+++ b/hackrf/device.go
@@ -63,6 +63,21 @@ func Open() (*Device, error) {
 	return &d, nil
 }
 
+func OpenBySerial(serial string) (*Device, error) {
+	if serial == "" {
+		return Open()
+	}
+
+	var d Device
+	cSerial := C.CString(serial)
+	defer C.free(unsafe.Pointer(cSerial))
+	if r := C.hackrf_open_by_serial(cSerial, &d.cdev); r != C.HACKRF_SUCCESS {
+		return nil, toError(r)
+	}
+
+	return &d, nil
+}
+
 func (d *Device) Close() error {
 	e := toError(C.hackrf_close(d.cdev))
 	if e == nil {

--- a/hackrf/device.go
+++ b/hackrf/device.go
@@ -115,7 +115,7 @@ func (d *Device) StartTX(cb Callback) error {
 		tx:  true,
 		dev: d,
 	})
-	return toError(C.hackrf_start_tx(d.cdev, (*[0]byte)(unsafe.Pointer(C.rxCBPtr)), unsafe.Pointer(uintptr(cbIx))))
+	return toError(C.hackrf_start_tx(d.cdev, (*[0]byte)(unsafe.Pointer(C.txCBPtr)), unsafe.Pointer(uintptr(cbIx))))
 }
 
 func (d *Device) StopTX() error {

--- a/hackrf/hackrf.go
+++ b/hackrf/hackrf.go
@@ -115,7 +115,7 @@ func DeviceList() ([]*DeviceInfo, error) {
 	if clist.devicecount < 1 {
 		return nil, nil
 	}
-	fmt.Printf("%d devices\n", clist.devicecount)
+	// fmt.Printf("%d devices\n", clist.devicecount)
 
 	serials := (*[1 << 30](*C.char))(unsafe.Pointer(clist.serial_numbers))[:clist.devicecount:clist.devicecount]
 	usbBoardIDs := (*[1 << 30](C.int))(unsafe.Pointer(clist.usb_board_ids))[:clist.devicecount:clist.devicecount]
@@ -129,6 +129,8 @@ func DeviceList() ([]*DeviceInfo, error) {
 			USBDeviceIndex: int(usbDeviceIndexes[i]),
 		}
 	}
+
+	C.hackrf_device_list_free(clist)
 
 	return devices, nil
 }

--- a/hackrf/hackrf_test.go
+++ b/hackrf/hackrf_test.go
@@ -1,29 +1,24 @@
 package hackrf
 
 import (
-	"fmt"
 	"testing"
 	"time"
 )
 
-func TestHackRF(t *testing.T) {
-	if err := Init(); err != nil {
-		t.Fatal(err)
-	}
-	defer Exit()
-	dev, err := Open()
+func testVer(dev *Device, t *testing.T) {
+	ver, err := dev.Version()
 	if err != nil {
 		t.Fatal(err)
+		return
 	}
-	defer dev.Close()
-	if ver, err := dev.Version(); err != nil {
-		t.Fatal(err)
-	} else {
-		t.Logf("Version: %s", ver)
-	}
+	t.Logf("Version: %s\n", ver)
+}
+
+func testRx(dev *Device, t *testing.T) {
 	total := 0
 	if err := dev.StartRX(func(buf []byte) error {
 		total += len(buf)
+		t.Logf("Rx: %d", len(buf))
 		return nil
 	}); err != nil {
 		t.Fatal(err)
@@ -32,5 +27,64 @@ func TestHackRF(t *testing.T) {
 	if err := dev.StopRX(); err != nil {
 		t.Fatal(err)
 	}
-	fmt.Printf("%d bytes\n", total)
+	t.Logf("Rx total: %d bytes\n", total)
+}
+
+func TestHackRF(t *testing.T) {
+	if err := Init(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := Exit(); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	var devs = make([]*DeviceInfo, 0)
+
+	t.Run("TestDeviceList", func(t *testing.T) {
+		var err error
+		if devs, err = DeviceList(); err != nil {
+			t.Fatal(err)
+			return
+		}
+		for i, dev := range devs {
+			t.Logf("Device %d: %s\n", i, dev.SerialNumber)
+		}
+	})
+
+	if len(devs) == 0 {
+		t.Skip("hackrf not found")
+		return
+	}
+
+	t.Run("TestOpen", func(t *testing.T) {
+		dev, err := Open()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if err = dev.Close(); err != nil {
+				t.Error(err)
+			}
+		}()
+
+		testVer(dev, t)
+		testRx(dev, t)
+	})
+
+	t.Run("TestOpenBySerial", func(t *testing.T) {
+		dev, err := OpenBySerial(devs[0].SerialNumber)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if err = dev.Close(); err != nil {
+				t.Error(err)
+			}
+		}()
+
+		testVer(dev, t)
+		testRx(dev, t)
+	})
 }


### PR DESCRIPTION
  - Add `OpenBySerial`
    - Add unit test
  - `ListDevices`
    - Free device list struct
    - Add unit test
    - Remove `fmt.Printf` call
  - General refactor of tests

 - Fix transmit callback pointer
